### PR TITLE
[JENKINS-20874] lazy load FindBugsMessages singleton

### DIFF
--- a/plugin/src/main/java/hudson/plugins/findbugs/FindBugsPlugin.java
+++ b/plugin/src/main/java/hudson/plugins/findbugs/FindBugsPlugin.java
@@ -1,11 +1,7 @@
 package hudson.plugins.findbugs;
 
-import java.io.IOException;
-
-import hudson.plugins.analysis.util.SaxSetup;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecution;
-import org.xml.sax.SAXException;
 
 import hudson.Plugin;
 
@@ -19,18 +15,11 @@ import hudson.plugins.analysis.views.DetailFactory;
  */
 public class FindBugsPlugin extends Plugin {
     @Override
-    public void start() throws IOException, SAXException {
-        SaxSetup sax = new SaxSetup();
-        try {
-            initializeMessages();
-        }
-        finally {
-            sax.cleanup();
-        }
+    public void start() {
+        initializeDetails();
     }
 
-    private void initializeMessages() throws IOException, SAXException {
-        FindBugsMessages.getInstance().initialize();
+    private void initializeDetails() {
         FindBugsDetailFactory detailBuilder = new FindBugsDetailFactory();
         DetailFactory.addDetailBuilder(FindBugsResultAction.class, detailBuilder);
         if (PluginDescriptor.isMavenPluginInstalled()) {

--- a/plugin/src/test/java/hudson/plugins/findbugs/FindBugsMessagesTest.java
+++ b/plugin/src/test/java/hudson/plugins/findbugs/FindBugsMessagesTest.java
@@ -101,16 +101,9 @@ public class FindBugsMessagesTest {
 
     /**
      * Checks that a warning message of each file is correctly parsed.
-     *
-     * @throws SAXException
-     *             if we can't read the file
-     * @throws IOException
-     *             if we can't read the file
      */
     @Test
-    public void parse() throws IOException, SAXException {
-        FindBugsMessages.getInstance().initialize();
-
+    public void parse() {
         assertTrue(WRONG_WARNING_MESSAGE, FindBugsMessages.getInstance().getMessage(NP_STORE_INTO_NONNULL_FIELD, Locale.ENGLISH).contains("A value that could be null is stored into a field that has been annotated as NonNull."));
         assertTrue(WRONG_WARNING_MESSAGE, FindBugsMessages.getInstance().getMessage(NP_STORE_INTO_NONNULL_FIELD, Locale.GERMAN).contains("A value that could be null is stored into a field that has been annotated as NonNull."));
         assertEquals(WRONG_WARNING_MESSAGE, "Store of null value into field annotated NonNull", FindBugsMessages.getInstance().getShortMessage(NP_STORE_INTO_NONNULL_FIELD, Locale.ENGLISH));
@@ -120,16 +113,9 @@ public class FindBugsMessagesTest {
 
     /**
      * Checks that localized messages are loaded.
-     *
-     * @throws SAXException
-     *             if we can't read the file
-     * @throws IOException
-     *             if we can't read the file
      */
     @Test
-    public void parseLocalizations() throws IOException, SAXException {
-        FindBugsMessages.getInstance().initialize();
-
+    public void parseLocalizations() {
         assertTrue(WRONG_WARNING_MESSAGE, FindBugsMessages.getInstance().getShortMessage(NP_STORE_INTO_NONNULL_FIELD, Locale.FRANCE).contains("Stocke une valeur null dans"));
         assertTrue(WRONG_WARNING_MESSAGE, FindBugsMessages.getInstance().getMessage(NP_STORE_INTO_NONNULL_FIELD, Locale.FRANCE).contains("Une valeur qui pourrait"));
     }

--- a/plugin/src/test/java/hudson/plugins/findbugs/parser/FindBugsParserTest.java
+++ b/plugin/src/test/java/hudson/plugins/findbugs/parser/FindBugsParserTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.*;
 import hudson.plugins.analysis.test.AbstractEnglishLocaleTest;
 import hudson.plugins.analysis.util.SaxSetup;
 import hudson.plugins.analysis.util.model.*;
-import hudson.plugins.findbugs.FindBugsMessages;
 import hudson.plugins.findbugs.Messages;
 
 /**
@@ -67,13 +66,9 @@ public class FindBugsParserTest extends AbstractEnglishLocaleTest {
      */
     @Test
     public void issue7238() throws IOException, SAXException, DocumentException {
-        FindBugsMessages.getInstance().initialize();
-
         MavenModule module = parseFile("issue7238.xml", false);
         assertEquals("Wrong number of warnings", 1820, module.getNumberOfAnnotations());
     }
-
-
 
     /**
      * Parses fb-contrib messages.
@@ -87,8 +82,6 @@ public class FindBugsParserTest extends AbstractEnglishLocaleTest {
      */
     @Test
     public void issue7238withIncludePattern() throws IOException, SAXException, DocumentException {
-        FindBugsMessages.getInstance().initialize();
-
         MavenModule module = parseFile("issue7238.xml", false, null, "*gti/plc/test*,*gti/plc/server/siemens/libnodave*,*gti/plc/util*");
         assertEquals("Wrong number of warnings", 68, module.getNumberOfAnnotations());
     }
@@ -105,8 +98,6 @@ public class FindBugsParserTest extends AbstractEnglishLocaleTest {
      */
     @Test
     public void issue7238withExcludePattern() throws IOException, SAXException, DocumentException {
-        FindBugsMessages.getInstance().initialize();
-
         MavenModule module = parseFile("issue7238.xml", false, "*gti/plc/test*,*gti/plc/server/siemens/libnodave*,*gti/plc/util*", null);
         assertEquals("Wrong number of warnings", 1752, module.getNumberOfAnnotations());
     }
@@ -123,8 +114,6 @@ public class FindBugsParserTest extends AbstractEnglishLocaleTest {
      */
     @Test
     public void issue7238withIncludeExcludePattern() throws IOException, SAXException, DocumentException {
-        FindBugsMessages.getInstance().initialize();
-
         MavenModule module = parseFile("issue7238.xml", false,
                 "*gti/plc/server/siemens/libnodave*", "*gti/plc/test*,*gti/plc/server/siemens/libnodave*,*gti/plc/util*");
         assertEquals("Wrong number of warnings", 57, module.getNumberOfAnnotations());
@@ -143,8 +132,6 @@ public class FindBugsParserTest extends AbstractEnglishLocaleTest {
      */
     @Test
     public void issue12314() throws IOException, SAXException, DocumentException {
-        FindBugsMessages.getInstance().initialize();
-
         MavenModule module = parseFile("issue12314.xml", false);
         assertEquals("Wrong number of warnings", 1, module.getNumberOfAnnotations());
 
@@ -168,8 +155,6 @@ public class FindBugsParserTest extends AbstractEnglishLocaleTest {
      */
     @Test
     public void issue7312and7932() throws IOException, SAXException, DocumentException {
-        FindBugsMessages.getInstance().initialize();
-
         String saxParser = this.getClass().getName();
         System.setProperty(SaxSetup.SAX_DRIVER_PROPERTY, saxParser);
         MavenModule module = parseFile("issue7312.xml", false);
@@ -190,8 +175,6 @@ public class FindBugsParserTest extends AbstractEnglishLocaleTest {
      */
     @Test
     public void issue7932Null() throws IOException, SAXException, DocumentException {
-        FindBugsMessages.getInstance().initialize();
-
         System.clearProperty(SaxSetup.SAX_DRIVER_PROPERTY);
         MavenModule module = parseFile("issue7312.xml", false);
         assertEquals("Wrong number of warnings", 0, module.getNumberOfAnnotations());
@@ -423,8 +406,6 @@ public class FindBugsParserTest extends AbstractEnglishLocaleTest {
             final int ranges1, final String fileName2, final String packageName2, final int start2, final int end2, final int ranges2, final boolean isRankActivated)
             throws IOException, SAXException, DocumentException {
    // CHECKSTYLE:ON
-        FindBugsMessages.getInstance().initialize();
-
         MavenModule module = parseFile(findbugsFile, isRankActivated);
         assertEquals("Wrong project name guessed", projectName, module.getName());
 


### PR DESCRIPTION
- implemented lazy initialization for FindBugsMessages singleton (using Initialization-on-demand holder idiom)
- I assumed the SaxSetup wrapper in FindBugsPlugin.start() was only needed for the parsing of message xmls
- i only ran "mvn test" to check if things still work (no integration tests)
- due to classloader semantics the synchronization block in FindBugsMessages.initialize() can probably be removed
