### PR TITLE
Added symbol name for better pipeline integration

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>commons-digester3</artifactId>
       <version>3.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
 
   <scm>

--- a/plugin/src/main/java/hudson/plugins/findbugs/FindBugsDescriptor.java
+++ b/plugin/src/main/java/hudson/plugins/findbugs/FindBugsDescriptor.java
@@ -2,6 +2,7 @@ package hudson.plugins.findbugs;
 
 import hudson.Extension;
 import hudson.plugins.analysis.core.PluginDescriptor;
+import org.jenkinsci.Symbol;
 
 /**
  * Descriptor for the class {@link FindBugsPublisher}. Used as a singleton. The
@@ -9,7 +10,7 @@ import hudson.plugins.analysis.core.PluginDescriptor;
  *
  * @author Ulli Hafner
  */
-@Extension(ordinal = 100)
+@Extension(ordinal = 100) @Symbol("findbugs")
 public final class FindBugsDescriptor extends PluginDescriptor {
     /** The ID of this plug-in is used as URL. */
     static final String PLUGIN_ID = "findbugs";


### PR DESCRIPTION
This will improve the syntax of using Findbugs from Jenkins Pipeline.

Before:
```
step([$class: 'FindBugsPublisher', pattern: 'target/findbugsXml.xml'])
```
After:
```
findbugs(pattern:'target/findbugsXml.xml')
```
